### PR TITLE
Initiail commit for Repo Score v2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright [2021] [Repo Score Author]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+## 项目说明
+给github和gitlab上面的工程评分， 基于[criticality_score](https://github.com/ossf/criticality_score)，增加了批量统计的功能
+
+## 使用方法
+设置GitHub Token：
+- 如果你还没有Token,[创建一个Github Token](https://docs.github.com/en/free-pro-team@latest/developers/apps/about-apps#personal-access-tokens)
+,设置环境变量 `GITHUB_AUTH_TOKEN`.
+这样可以避免Github的[api用量限制](https://developer.github.com/v3/#rate-limiting)
+
+```shell
+export GITHUB_AUTH_TOKEN=<your access token>
+```
+如果你统计的项目里有GitLab的项目，还需要设置GitLab的Token：
+- 如果你还没有，[创建一个Gitlab Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
+,设置环境变量 `GITLAB_AUTH_TOKEN`.
+
+准备工程的url列表文件，一行一个url, 格式可以参考本项目reposcore目录下的projects.txt文件
+
+```shell
+pip3 uninstall python-gitlab PyGithub
+pip3 install python-gitlab PyGithub
+git clone https://github.com/kunpengcompute/reposcore
+cd reposcore
+python3 setup.py install
+reposcore --projects_list projects_url_file --result_file result.csv
+```
+
+最终输出为csv格式的文件
+
+## Project Description 
+Score github or gitlab's projects, based on [criticality_score](https://github.com/ossf/criticality_score), added batch function.
+## Usage
+Before running, you need to:
+
+For GitHub repos, you need to [create a GitHub access token](https://docs.github.com/en/free-pro-team@latest/developers/apps/about-apps#personal-access-tokens) and set it in environment variable `GITHUB_AUTH_TOKEN`. 
+```shell
+export GITHUB_AUTH_TOKEN=<your access token>
+```
+For GitLab repos, you need to [create a GitLab access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) and set it in environment variable `GITLAB_AUTH_TOKEN`. 
+
+
+Prepare a projects url file, one url per line, please refer to projects.txt under directory reposcore.
+```shell
+pip3 uninstall python-gitlab PyGithub
+pip3 install python-gitlab PyGithub
+git clone https://github.com/kunpengcompute/reposcore
+cd reposcore
+python3 setup.py install
+reposcore --projects_list projects_url_file --result_file result.csv
+```
+The final output is a csv format file.
+

--- a/reposcore/projects.txt
+++ b/reposcore/projects.txt
@@ -1,0 +1,2 @@
+https://github.com/kubernetes/kubernetes
+https://github.com/tensorflow/tensorflow

--- a/reposcore/reposcore.py
+++ b/reposcore/reposcore.py
@@ -1,0 +1,85 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Main python script for calculating OSS Criticality Score."""
+
+import argparse
+import csv
+import os
+import sys
+import time
+
+from criticality_score import run
+
+
+def init_constants():
+    # See more constants in:
+    # https://github.com/ossf/criticality_score/blob/main/criticality_score/constants.py
+    run.CONTRIBUTOR_COUNT_WEIGHT = 1
+    run.ORG_COUNT_WEIGHT = 0.5
+    run.COMMIT_FREQUENCY_WEIGHT = 4
+    run.COMMENT_FREQUENCY_WEIGHT = 0.5
+    run.DEPENDENTS_COUNT_WEIGHT = 1
+
+
+def main():
+    init_constants()
+    parser = argparse.ArgumentParser(
+        description=
+        'Generate a sorted criticality score list for input projects .')
+    parser.add_argument("--projects_list",
+                        type=open,
+                        required=True,
+                        help="File name of projects url list.")
+    parser.add_argument("--result_file",
+                        type=str,
+                        required=True,
+                        help="Result file name.")
+
+    args = parser.parse_args()
+
+    repo_urls = set()
+    repo_urls.update(args.projects_list.read().splitlines())
+
+    csv_writer = csv.writer(sys.stdout)
+    header = None
+    stats = []
+    for repo_url in repo_urls:
+        output = None
+        for _ in range(3):
+            try:
+                repo = run.get_repository(repo_url)
+                output = run.get_repository_stats(repo)
+                break
+            except Exception as exp:
+                print(
+                    f'Exception occurred when reading repo: {repo_url}\n{exp}')
+        if not output:
+            continue
+        if not header:
+            header = output.keys()
+            csv_writer.writerow(header)
+        csv_writer.writerow(output.values())
+        stats.append(output)
+
+    with open(args.result_file, 'w') as file_handle:
+        csv_writer = csv.writer(file_handle)
+        csv_writer.writerow(header)
+        for i in sorted(stats,
+                        key=lambda i: i['criticality_score'],
+                        reverse=True):
+            csv_writer.writerow(i.values())
+    print(f'Wrote results: {args.result_file}')
+
+
+if __name__ == "__main__":
+    main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+criticality_score

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""setup.py for Repo Score projects"""
+import setuptools
+
+with open('README.md', 'r') as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name='reposcore',
+    version='2.0.0',
+    author='KunpengCompute',
+    author_email='',
+    description='Gives scores for open source projects',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    url='https://github.com/kunpengcompute/reposcore',
+    packages=setuptools.find_packages(),
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+    ],
+    install_requires=[
+        'criticality_score',
+        'PyGithub>=1.53',
+        'python-gitlab>=2.5.0',
+    ],
+    entry_points={
+        'console_scripts': ['reposcore=reposcore.reposcore:main'],
+    },
+    python_requires='>=3',
+    zip_safe=False,
+)
+


### PR DESCRIPTION
The Repo Score v1 is forked from criticality_score and had much not graceful modification on upstream code, after the discussion[1], we decided to decouple the dependency of criticality_score.

So in this patch, we keep the v1 code and doc unchanged, only move the criticality_score into requirements, and then set the `setup.py` version to 2.0.0 to avoid the pypi reupload problem [2].

[1] https://github.com/kunpengcompute/reposcore/issues/1
[2] https://github.com/pypa/packaging-problems/issues/74

Close: #1