### PR TITLE
Refactor for repo stat

### DIFF
--- a/etc/reposcore.conf
+++ b/etc/reposcore.conf
@@ -30,16 +30,16 @@ commit_frequency_weight = 4
 
 # Number of releases in the last year, frequent releases indicates user
 # dependency at some level(Lower weight since this is not always used)
-recent_releases_weight = 0.5
+recent_releases_count_weight = 0.5
 
 # Number of issues closed in the last 90 days, indicates high contributor
 # involvement and focus on closing user issues(Lower weight since it is
 # dependent on project contributors)
-closed_issues_weight = 0.5
+closed_issues_count_weight = 0.5
 
 # Number of issues updated in the last 90 days, indicates high contributor
 # involvement(Lower weight since it is dependent on project contributors)
-updated_issues_weight = 0.5
+updated_issues_count_weight = 0.5
 
 # Average number of comments per issue in the last 90 days, indicates
 # high user activity and dependence
@@ -48,3 +48,15 @@ comment_frequency_weight = 0.5
 # Number of project mentions in the commit messages, indicates repository
 # use, usually in version rolls
 dependents_count_weight = 1
+
+[threshold]
+created_since_threshold = 120
+updated_since_threshold = 120
+contributor_count_threshold = 5000
+org_count_threshold = 10
+commit_frequency_threshold = 1000
+recent_releases_count_threshold = 26
+closed_issues_count_threshold = 5000
+updated_issues_count_threshold = 5000
+comment_frequency_threshold = 15
+dependents_count_threshold = 500000

--- a/reposcore/cli.py
+++ b/reposcore/cli.py
@@ -30,10 +30,6 @@ class RepoScore(object):
         self.retry = int(self.config.get('global', 'retry'))
 
 
-        cs_run.PARAMS.append("code_line_change_recent_year")
-        cs_run.PARAMS.append("activity_contributor_count_recent_year")
-
-
     def _create_parser(self):
         parser = argparse.ArgumentParser(
             description=

--- a/reposcore/cli.py
+++ b/reposcore/cli.py
@@ -19,8 +19,7 @@ import sys
 import time
 
 from reposcore.repo import repo as rs_repo
-
-from criticality_score import run as cs_run
+from reposcore.stat import stat as rs_stat
 
 
 class RepoScore(object):
@@ -30,31 +29,6 @@ class RepoScore(object):
         self.config = self._initConfig()
         self.retry = int(self.config.get('global', 'retry'))
 
-        self._init_constants()
-
-    def _init_constants(self):
-        # See more constants in:
-        # https://github.com/ossf/criticality_score/blob/main/criticality_score/constants.py
-        cs_run.CREATED_SINCE_WEIGHT = float(
-            self.config.get('weight', 'created_since_weight'))
-        cs_run.UPDATED_SINCE_WEIGHT = float(
-            self.config.get('weight', 'updated_since_weight'))
-        cs_run.CONTRIBUTOR_COUNT_WEIGHT = float(
-            self.config.get('weight', 'contributor_count_weight'))
-        cs_run.ORG_COUNT_WEIGHT = float(
-            self.config.get('weight', 'org_count_weight'))
-        cs_run.COMMIT_FREQUENCY_WEIGHT = float(
-            self.config.get('weight', 'commit_frequency_weight'))
-        cs_run.RECENT_RELEASES_WEIGHT = float(
-            self.config.get('weight', 'recent_releases_weight'))
-        cs_run.CLOSED_ISSUES_WEIGHT = float(
-            self.config.get('weight', 'closed_issues_weight'))
-        cs_run.UPDATED_ISSUES_WEIGHT = float(
-            self.config.get('weight', 'updated_issues_weight'))
-        cs_run.COMMENT_FREQUENCY_WEIGHT = float(
-            self.config.get('weight', 'comment_frequency_weight'))
-        cs_run.DEPENDENTS_COUNT_WEIGHT = float(
-            self.config.get('weight', 'dependents_count_weight'))
 
         cs_run.PARAMS.append("code_line_change_recent_year")
         cs_run.PARAMS.append("activity_contributor_count_recent_year")
@@ -101,7 +75,8 @@ class RepoScore(object):
             for _ in range(self.retry):
                 try:
                     repo = rs_repo.get_repository(repo_url, self.config)
-                    output = cs_run.get_repository_stats(repo)
+                    stat = rs_stat.Stat(self.config, repo)
+                    output = stat.get_stats()
                     break
                 except Exception as exp:
                     print('Failed reading repo %s\n. Detail: %s' % (

--- a/reposcore/repo/repo.py
+++ b/reposcore/repo/repo.py
@@ -100,6 +100,7 @@ class GitHubRepository(cs_run.GitHubRepository, GitLocalRepo):
     def __init__(self, repo, config):
         cs_run.GitHubRepository.__init__(self, repo)
         GitLocalRepo.__init__(self, repo, config)
+        self.retry = int(config.get('global', 'retry'))
 
     # TODO(yikun): Re-implementation in GitLocalRepo
     def get_first_commit_time(self):
@@ -116,7 +117,7 @@ class GitHubRepository(cs_run.GitHubRepository, GitLocalRepo):
             return links
 
         headers = {'Authorization': f'token {token._CACHED_GITHUB_TOKEN}'}
-        for i in range(3):
+        for i in range(self.retry):
             result = requests.get(f'{self._repo.url}/commits', headers=headers)
             links = _parse_links(result)
             if links and links.get('last'):

--- a/reposcore/repo/token.py
+++ b/reposcore/repo/token.py
@@ -1,3 +1,14 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import datetime
 import os
 import sys

--- a/reposcore/stat/stat.py
+++ b/reposcore/stat/stat.py
@@ -1,0 +1,84 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import math
+import sys
+import threading
+
+
+class Stat():
+    def __init__(self, conf, repo):
+        self.params = [
+            'created_since', 'updated_since',
+            'contributor_count', 'org_count',
+            'commit_frequency', 'recent_releases_count',
+            'updated_issues_count', 'closed_issues_count',
+            'comment_frequency', 'dependents_count'
+        ]
+        self.conf = conf
+        self.repo = repo
+
+
+    def get_score(self, s, max_value, weigt):
+        # map score between [0, 1]
+        return (math.log(1 + s) / math.log(1 + max(s, max_value))) * weigt
+
+
+    def _get_repository_stats(self):
+        """Return repository stats, including criticality score."""
+
+        def _worker(repo, param, return_dict):
+            """worker function"""
+            return_dict[param] = getattr(repo, param)
+
+        threads = []
+        return_dict = {}
+
+        for param in self.params:
+            thread = threading.Thread(
+                target=_worker, args=(self.repo, param, return_dict))
+            thread.start()
+            threads.append(thread)
+        for thread in threads:
+            thread.join()
+
+        # Guarantee insertion order.
+        result_dict = {
+            'name': self.repo.name,
+            'url': self.repo.url,
+            'language': self.repo.language,
+        }
+        for param in self.params:
+            result_dict[param] = return_dict[param]
+        return result_dict
+
+    def get_stats(self):
+        res = self._get_repository_stats()
+
+        total_weight = sum([float(
+            self.conf.get('weight', s+"_weight")) for s in self.params]
+            )
+
+        score = 0
+        for s in self.params:
+            score += self.get_score(
+                res[s],
+                float(self.conf.get('threshold', s+"_threshold")),
+                float(self.conf.get('weight', s+"_weight"))
+            )
+
+        score = round(score/total_weight, 5)
+
+        # Make sure score between 0 (least-critical) and 1 (most-critical). 
+        score = max(min(score, 1), 0)
+
+        res['criticality_score'] = score
+        return res

--- a/reposcore/stat/stat.py
+++ b/reposcore/stat/stat.py
@@ -23,6 +23,11 @@ class Stat():
             'updated_issues_count', 'closed_issues_count',
             'comment_frequency', 'dependents_count'
         ]
+        # the etra params but not sum in score
+        self.extra_params = [
+            'code_line_change_recent_year',
+            'activity_contributor_count_recent_year'
+        ]
         self.conf = conf
         self.repo = repo
 
@@ -42,7 +47,9 @@ class Stat():
         threads = []
         return_dict = {}
 
-        for param in self.params:
+        all_params = self.params + self.extra_params
+
+        for param in all_params:
             thread = threading.Thread(
                 target=_worker, args=(self.repo, param, return_dict))
             thread.start()
@@ -56,7 +63,7 @@ class Stat():
             'url': self.repo.url,
             'language': self.repo.language,
         }
-        for param in self.params:
+        for param in all_params:
             result_dict[param] = return_dict[param]
         return result_dict
 


### PR DESCRIPTION
This patch didn't add any new feature, only do some refactor to make repo statis work.

1. Add `stat.py` to take over `cs_run.get_repository_stats` work.
2. move the get_first_commit_time from `criticality_score` repo into `reposcore`, because `token._CACHED_GITHUB_TOKEN` should be used rather than `_CACHED_GITHUB_TOKEN`. And we will also re-implement it in GitLocalRepo in future.
3. remove all `_init_constants` code, because we have self.config now.
4. add `[threshold]` secitons, rename some weight conf key to keep score key, threshold, weight names consistent.