### PR TITLE
Add code effort and core effort

### DIFF
--- a/reposcore/stat/stat.py
+++ b/reposcore/stat/stat.py
@@ -25,8 +25,10 @@ class Stat():
         # the etra params but not sum in score
         self.extra_params = [
             'code_line_change_recent_year',
+            'code_effort',
             'core_line_change_recent_year',
-            'activity_contributor_count_recent_year'
+            'core_effort',
+            'activity_contributor_count_recent_year',
         ]
         self.conf = conf
         self.repo = repo


### PR DESCRIPTION
If a developer write 20 lines code everyday, then we can use the
`code lines addtion number / (20 loc * 22 work days * 12 month)`
to generate how many people should be full time to complete these
code.

This patch adds 2 extra params: `code_effort`, `core_effort`. This
patch also add the `threadsafe lru` to avoid the concurrent error and
speed up the result fetching.