### PR TITLE
Improve activity contriutor.

### DIFF
--- a/reposcore/utils/matrix.py
+++ b/reposcore/utils/matrix.py
@@ -1,12 +1,3 @@
-# This List contains the contributor name that can't be deal with json format.
-AUTHOR_FIX_MAPPING = [
-    ('freedom"', 'freedom'),
-    ('"henyxia"', 'henyxia'),
-    ('"Tempa Kyouran"', 'Tempa Kyouran'),
-    ('"TBBle"', 'TBBle'),
-]
-
-
 # This list contains the project that `git` tool is broken.
 BROKEN_PROJECT_MAPPING = {
     'openstack/openstack': [


### PR DESCRIPTION
In the first version of activity_contributor use the json format to
store the name and email info, and then parse the name part. Due to
the double quota problem, we may get the a bad name, so we have to
map the name string.

This patch only use the contributor name rather than info json, to
calculate the contributions, we didn't change any feature in this
patch, just a reafactor.

related: https://github.com/kunpengcompute/reposcore/issues/37